### PR TITLE
Add Mushr Extension to Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Foxglove Studio under the extension sidebar.
 ## Extensions
 
 - [Turtlesim](https://github.com/foxglove/studio-extension-turtlesim) – Interact with the ROS turtlesim node
+- [MuShr](https://github.com/mcdoerr/foxglove-mushr-extension) - Use custom buttons with the MuShr package

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Foxglove Studio under the extension sidebar.
 ## Extensions
 
 - [Turtlesim](https://github.com/foxglove/studio-extension-turtlesim) – Interact with the ROS turtlesim node
-- [MuShr](https://github.com/mcdoerr/foxglove-mushr-extension) - Use custom buttons with the MuShr package
+- [MuSHR](https://github.com/mcdoerr/foxglove-mushr-extension) - Use custom buttons with the MuShr package

--- a/extensions.json
+++ b/extensions.json
@@ -24,7 +24,7 @@
     "license": "UNLICENSED",
     "version": "0.0.0",
     "sha256sum": "739e3010d142fbdcccedea73c9653575542515a28af85b25dc92c8b93ae10bc7",
-    "foxe": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/releases/uwprl.MushrTeleopButtons-0.0.0.foxe",
+    "foxe": "https://github.com/mcdoerr/foxglove-mushr-extension/raw/main/releases/uwprl.MushrTeleopButtons-0.0.0.foxe",
     "keywords": ["mushr","simulator"]
   }
 ]

--- a/extensions.json
+++ b/extensions.json
@@ -16,7 +16,7 @@
   {
     "id": "uwprl.studio-extension-mushr",
     "name": "mushr",
-    "description": "Custom buttons for differentiating publish types for the MuShr base package",
+    "description": "Custom buttons for differentiating publish types for the MuSHR base package",
     "publisher": "uwprl",
     "homepage": "https://github.com/mcdoerr/foxglove-mushr-extension",
     "readme": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/README.md",

--- a/extensions.json
+++ b/extensions.json
@@ -12,5 +12,19 @@
     "sha256sum": "6fb9647d5e202f2e030cd16a36706a43481d5065a54669967db68690e2199338",
     "foxe": "https://github.com/foxglove/studio-extension-turtlesim/releases/download/v0.0.1/foxglove.studio-extension-turtlesim-0.0.1.foxe",
     "keywords": ["ros","turtlesim","turtle","simulator","tutorial"]
+  },
+  {
+    "id": "uwprl.studio-extension-mushr",
+    "name": "mushr",
+    "description": "Custom buttons for differentiating publish types for the MuShr base package",
+    "publisher": "uwprl",
+    "homepage": "https://github.com/mcdoerr/foxglove-mushr-extension",
+    "readme": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/README.md",
+    "changelog": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/CHANGELOG.md",
+    "license": "UNLICENSED",
+    "version": "0.0.0",
+    "sha256sum": "",
+    "foxe": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/releases/uwprl.MushrTeleopButtons-0.0.0.foxe",
+    "keywords": ["mushr","simulator"]
   }
 ]

--- a/extensions.json
+++ b/extensions.json
@@ -23,7 +23,7 @@
     "changelog": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/CHANGELOG.md",
     "license": "UNLICENSED",
     "version": "0.0.0",
-    "sha256sum": "",
+    "sha256sum": "739e3010d142fbdcccedea73c9653575542515a28af85b25dc92c8b93ae10bc7",
     "foxe": "https://github.com/mcdoerr/foxglove-mushr-extension/blob/main/releases/uwprl.MushrTeleopButtons-0.0.0.foxe",
     "keywords": ["mushr","simulator"]
   }


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
Add a small extension to the marketplace with publishing buttons for the MuSHR package. See [this repo](https://github.com/mcdoerr/foxglove-mushr-extension) with the extension for details. 

**Description**
<!-- describe what has changed, and motivation behind those changes -->
For the MuSHR package, we need 3 types of `PoseStamped` click-to-publish points. In our simulation, we need to be able to set the robot position, and for our real robot, we need to publish a point close to the robot. Finally, we need to be able to publish navigation goals for the robot on both simulation and real robot. The user can select the buttons on the MuSHR extension to change the way that the `PoseStamped` message is interpreted on the MuSHR backend for our 3 different pose types.

<!-- link relevant GitHub issues -->
