### PR TITLE
Add Blank Panel to Readme and extensions.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Foxglove Studio under the extension sidebar.
 
 # Extensions
 
-- [Turtlesim](https://github.com/foxglove/studio-extension-turtlesim) – Interact with the ROS turtlesim node
+- [Blank Panel](https://github.com/foxglove/blank-panel-extension) – Add a little space to your layout
 - [MuSHR](https://github.com/mcdoerr/foxglove-mushr-extension) – Use custom buttons with the MuShr package
+- [Turtlesim](https://github.com/foxglove/studio-extension-turtlesim) – Interact with the ROS turtlesim node
 - [SidewaysTeleop](https://github.com/rscova/foxglove-sideways-teleop-extension) – Use an Xbox controller to control a robot
 - [ROS2 Parameters](https://github.com/danclapp4/ros2-parameter-extension) - Interact with ROS2 Parameters

--- a/extensions.json
+++ b/extensions.json
@@ -14,6 +14,20 @@
     "keywords": ["ros","turtlesim","turtle","simulator","tutorial"]
   },
   {
+    "id": "foxglove.blank-panel-extension",
+    "name": "Blank Panel",
+    "description": "Add a little space to your layout",
+    "publisher": "foxglove",
+    "homepage": "https://github.com/foxglove/blank-panel-extension",
+    "readme": "https://raw.githubusercontent.com/foxglove/blank-panel-extension/main/README.md",
+    "changelog": "https://raw.githubusercontent.com/foxglove/blank-panel-extension/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "1.0.0",
+    "sha256sum": "fa2b11af8ed7c420ca6e541196bca608661c0c1a81cd1f768c565c72a55a63c8",
+    "foxe": "https://github.com/foxglove/blank-panel-extension/releases/download/v1.0.0/foxglove.blank-panel-extension-1.0.0.foxe",
+    "keywords": ["blank","panel","empty","logo","spacer"]
+  },
+  {
     "id": "uwprl.studio-extension-mushr",
     "name": "mushr",
     "description": "Custom buttons for differentiating publish types for the MuSHR base package",


### PR DESCRIPTION
**Public-Facing Changes**
Add blank panel as extension to the marketplace.

<img width="1376" alt="Screen Shot 2022-10-25 at 1 00 46 pm" src="https://user-images.githubusercontent.com/924528/197664626-6f2c545a-1d51-41b3-ab48-afe24d1aa5b1.png">