### PR TITLE
New 2D orientation panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Foxglove Studio under the extension sidebar.
 - [ROS2 Parameters](https://github.com/danclapp4/ros2-parameter-extension) - Interact with ROS2 Parameters
 - [Virtual Joystick](https://github.com/yulong88888/foxglove-nipple) - Easier to use twist topic publisher
 - [H264 Video Playback](https://github.com/codewithpassion/foxglove-studio-h264-extension) - Experimental H264 video playback
+- [2D orientation](https://github.com/CourchesneA/foxglove-orientation-panel) - Visualize 2D orientation from ros imu or quaternion messages

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Foxglove Studio under the extension sidebar.
 - [ROS2 Parameters](https://github.com/danclapp4/ros2-parameter-extension) - Interact with ROS2 Parameters
 - [Virtual Joystick](https://github.com/yulong88888/foxglove-nipple) - Easier to use twist topic publisher
 - [H264 Video Playback](https://github.com/codewithpassion/foxglove-studio-h264-extension) - Experimental H264 video playback
-- [2D orientation](https://github.com/CourchesneA/foxglove-orientation-panel) - Visualize 2D orientation from ros imu or quaternion messages
+- [2D orientation](https://github.com/CourchesneA/foxglove-orientation-panel) - Visualize 2D orientation from ROS imu or quaternion messages

--- a/extensions.json
+++ b/extensions.json
@@ -96,5 +96,19 @@
     "sha256sum": "87e0a4fe397974fb2e3771f370009ccdbe195498d4792c04bc08b2e2482bda71",
     "foxe": "https://github.com/codewithpassion/foxglove-studio-h264-extension/releases/download/v0.1.0/missionrobotics.h264-panel-0.1.0.foxe",
     "keywords": ["video", "h264"]
+  },
+    {
+    "id": "ivi.orientation-extension",
+    "name": "orientation",
+    "description": "Display object orientation in 2D space",
+    "publisher": "IVI",
+    "homepage": "https://github.com/CourchesneA/foxglove-orientation-panel",
+    "readme": "https://github.com/CourchesneA/foxglove-orientation-panel/blob/main/README.md",
+    "changelog": "https://github.com/CourchesneA/foxglove-orientation-panel/blob/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "0.0.1",
+    "sha256sum": "6afa4437c45cb5b60a99405e40b0c51b4edfcc0f9a640532cc218962da1ee2b8",
+    "foxe": "https://github.com/CourchesneA/foxglove-orientation-panel/releases/download/v0.0.1/ivi.orientation-extension-0.0.1.foxe",
+    "keywords": ["orientation","2d","ros","ros2"]
   }
 ]

--- a/extensions.json
+++ b/extensions.json
@@ -97,7 +97,7 @@
     "foxe": "https://github.com/codewithpassion/foxglove-studio-h264-extension/releases/download/v0.1.0/missionrobotics.h264-panel-0.1.0.foxe",
     "keywords": ["video", "h264"]
   },
-    {
+  {
     "id": "ivi.orientation-extension",
     "name": "orientation",
     "description": "Display object orientation in 2D space",


### PR DESCRIPTION
### Public-Facing Changes

New extension

### Description

Add an extension to visualize orientation of a ROS imu or quaternion message on a compass

![image](https://user-images.githubusercontent.com/16596299/228543343-7fb7a390-59be-43df-a94b-f41563fb67f2.png)
