### PR TITLE
feat(autoware_foxglove_converter): add autoware converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Foxglove Studio under the extension sidebar.
 - [2D orientation](https://github.com/CourchesneA/foxglove-orientation-panel) - Visualize 2D orientation from ROS imu or quaternion messages
 - [Battery level indicator](https://github.com/Lynxdrone/foxglove-battery-extension) - Compact battery level indicator
 - [Joystick/gamepad control](https://github.com/joshnewans/foxglove-joystick) - Receive/monitor/generate joystick and gamepad controls
+- [Autoware msgs](https://github.com/kminoda/AutowareFoxgloveConverter) - Load Autoware related msgs

--- a/extensions.json
+++ b/extensions.json
@@ -166,5 +166,19 @@
     "sha256sum": "5b2dbe3280a7833c8d827e4f3b8acfa4df9cf4cd16a5db037885a6cfcdd42041",
     "foxe": "https://github.com/joshnewans/foxglove-webcam/releases/download/0.0.2/joshnewans.webcam-panel-0.0.2.foxe",
     "keywords": ["ros","webcam"]
-  }
+  },
+  {
+    "id": "kminoda.autoware-msgs",
+    "name": "Autoware Msgs",
+    "description": "Autoware messages",
+    "publisher": "Koji Minoda",
+    "homepage": "https://github.com/kminoda/AutowareFoxgloveConverter",
+    "readme": "https://github.com/kminoda/AutowareFoxgloveConverter/blob/main/README.md",
+    "changelog": "https://github.com/kminoda/AutowareFoxgloveConverter/blob/main/CHANGELOG.md",
+    "license": "Apache 2.0",
+    "version": "0.0.1",
+    "sha256sum": "d7b831c665111aeab5779bea6f5b8f7d5c3afa6d2200d1f79ba2bafbb799497c",
+    "foxe": "https://github.com/kminoda/AutowareFoxgloveConverter/releases/download/v0.0.1/kminoda.AutowareFoxgloveConverter-0.0.1.foxe",
+    "keywords": ["ros", "autoware"]
+  },
 ]


### PR DESCRIPTION
### Public-Facing Changes

Add an extension to read Autoware msgs implemented here: https://github.com/kminoda/AutowareFoxgloveConverter
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description

With this, you will be able to load some of the messages defined in Autoware: https://github.com/autowarefoundation/autoware

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
